### PR TITLE
Fetch user name from session

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,19 +1,22 @@
-
-
 "use client";
-import React from "react";
+import React, { PropsWithChildren, useEffect, useState } from "react";
 import { Navbar, Sidebar } from "@/components";
 import { ClientProvider } from "@/context/ClientContext";
 import { useToggle } from "@/hooks/useToggle";
-
-import { PropsWithChildren } from "react";
+import { getLoggedInUserName } from "@/lib/auth";
 
 export default function DashboardLayout({ children }: PropsWithChildren<object>) {
   const { value: isCollapsed, set: setIsCollapsed } = useToggle(false);
   const { value: isMobileMenuOpen, set: setIsMobileMenuOpen } = useToggle(false);
-  // Replace this with actual logic to get the client name
+  const [clientName, setClientName] = useState("John Anderson");
+
+  useEffect(() => {
+    const name = getLoggedInUserName();
+    if (name) setClientName(name);
+  }, []);
+
   return (
-    <ClientProvider clientName="John Anderson">
+    <ClientProvider clientName={clientName}>
       <div className="flex">
         <Sidebar
           isCollapsed={isCollapsed}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,5 @@
+export function getLoggedInUserName(): string | null {
+  if (typeof window === 'undefined') return null;
+  const name = sessionStorage.getItem('clientName');
+  return name;
+}


### PR DESCRIPTION
## Summary
- get client name from session storage
- inject actual client name into dashboard layout

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_688aad47a2e8833298a9a2b2f64c808b