### PR TITLE
Add Shadcn-style UI components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 "use client"
 import React, { useState } from 'react';
 import { Eye, EyeOff, Waves } from 'lucide-react';
+import { Button, Input, Card, CardContent } from '@/components/ui';
 import { useRouter } from 'next/navigation';
 
 
@@ -57,7 +58,8 @@ export default function LoginPage() {
         </div>
 
         {/* Login Form */}
-        <div className="bg-white rounded-2xl shadow-xl p-8 border border-slate-200">
+        <Card className="p-8">
+          <CardContent className="p-0">
           <h2 className="text-2xl font-semibold text-slate-800 mb-6 text-center">
             Welcome Back
           </h2>
@@ -74,12 +76,11 @@ export default function LoginPage() {
               <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">
                 Email Address
               </label>
-              <input
+              <Input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-slate-50 focus:bg-white"
                 placeholder="Enter your email"
                 disabled={isLoading}
               />
@@ -91,23 +92,25 @@ export default function LoginPage() {
                 Password
               </label>
               <div className="relative">
-                <input
+                <Input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-3 pr-12 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-slate-50 focus:bg-white"
+                  className="pr-12"
                   placeholder="Enter your password"
                   disabled={isLoading}
                 />
-                <button
+                <Button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
                   disabled={isLoading}
                 >
                   {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
-                </button>
+                </Button>
               </div>
             </div>
 
@@ -127,11 +130,11 @@ export default function LoginPage() {
             </div>
 
             {/* Login Button */}
-            <button
+            <Button
               type="button"
               onClick={handleLogin}
               disabled={isLoading}
-              className="w-full bg-gradient-to-r from-blue-600 to-teal-600 text-white py-3 px-4 rounded-lg font-medium hover:from-blue-700 hover:to-teal-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-[1.02] active:scale-[0.98]"
+              className="w-full bg-gradient-to-r from-blue-600 to-teal-600 hover:from-blue-700 hover:to-teal-700 transform hover:scale-[1.02] active:scale-[0.98]"
             >
               {isLoading ? (
                 <div className="flex items-center justify-center">
@@ -141,7 +144,7 @@ export default function LoginPage() {
               ) : (
                 'Sign In'
               )}
-            </button>
+            </Button>
           </div>
 
           {/* Demo Credentials */}
@@ -150,7 +153,8 @@ export default function LoginPage() {
             <p className="text-sm text-blue-700">Email: demo@bluemarina.com</p>
             <p className="text-sm text-blue-700">Password: demo123</p>
           </div>
-        </div>
+          </CardContent>
+        </Card>
 
         {/* Footer */}
         <div className="text-center mt-8 text-sm text-slate-500">

--- a/src/components/DashboardContent.tsx
+++ b/src/components/DashboardContent.tsx
@@ -9,6 +9,7 @@ import {
   Eye
 } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import { Button } from '@/components/ui';
 
 // Dummy data for portfolio performance
 const portfolioData = [
@@ -209,10 +210,10 @@ export default function DashboardContent({ clientName }: DashboardContentProps) 
       <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
         <div className="flex items-center justify-between mb-6">
           <h3 className="text-lg font-semibold text-slate-900">Recent Transactions</h3>
-          <button className="flex items-center space-x-2 text-blue-600 hover:text-blue-800 text-sm font-medium">
+          <Button variant="ghost" size="default" className="flex items-center space-x-2 text-blue-600 hover:text-blue-800 text-sm font-medium">
             <Eye className="h-4 w-4" />
             <span>View All</span>
-          </button>
+          </Button>
         </div>
         <div className="space-y-4">
           {recentTransactions.map((transaction) => (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from 'react';
 import { Bell, User, Menu } from 'lucide-react';
+import { Button } from '@/components/ui';
 import { useClient } from '@/context/ClientContext';
 
 interface NavbarProps {
@@ -18,12 +19,14 @@ export default function Navbar({
       <div className="px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Mobile Menu Button */}
-          <button
-            className="md:hidden p-2 rounded-lg hover:bg-slate-100"
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
             onClick={() => setIsMobileMenuOpen(true)}
           >
             <Menu className="h-5 w-5 text-slate-600" />
-          </button>
+          </Button>
 
           {/* Page Title */}
           <div className="flex-1 md:flex-none">
@@ -32,10 +35,10 @@ export default function Navbar({
 
           {/* Header Actions */}
           <div className="flex items-center space-x-4">
-            <button className="relative p-2 text-slate-600 hover:text-slate-900 rounded-lg hover:bg-slate-100">
+            <Button variant="ghost" size="icon" className="relative text-slate-600 hover:text-slate-900">
               <Bell className="h-5 w-5" />
               <span className="absolute top-1 right-1 h-2 w-2 bg-red-500 rounded-full"></span>
-            </button>
+            </Button>
             <div className="hidden md:flex items-center space-x-2">
               <div className="bg-blue-100 p-2 rounded-full">
                 <User className="h-5 w-5 text-blue-600" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   X
 } from 'lucide-react';
 import { useClient } from '@/context/ClientContext';
+import { Button } from '@/components/ui';
 
 // Navigation items
 const navItems = [
@@ -62,21 +63,24 @@ export default function Sidebar({
               </div>
             )}
             {isCollapsed && (
-              <button
+              <Button
                 onClick={() => setIsCollapsed(false)}
-                className="bg-gradient-to-r from-blue-600 to-teal-600 p-2 rounded-lg mx-auto hover:shadow-lg transition-all duration-200"
+                className="bg-gradient-to-r from-blue-600 to-teal-600 p-2 mx-auto hover:shadow-lg transition-all duration-200"
                 title="Expand Sidebar"
+                size="icon"
               >
                 <Waves className="h-6 w-6 text-white" />
-              </button>
+              </Button>
             )}
             {!isCollapsed && (
-              <button
+              <Button
                 onClick={() => setIsCollapsed(!isCollapsed)}
-                className="p-1 rounded-lg hover:bg-slate-100 transition-colors"
+                variant="ghost"
+                size="icon"
+                className="p-1"
               >
                 <ChevronLeft className="h-4 w-4 text-slate-600" />
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -141,12 +145,14 @@ export default function Sidebar({
                     <p className="text-xs text-slate-600">Asset Management</p>
                   </div>
                 </div>
-                <button
+                <Button
                   onClick={() => setIsMobileMenuOpen(false)}
-                  className="p-2 rounded-lg hover:bg-slate-100"
+                  variant="ghost"
+                  size="icon"
+                  className="p-2"
                 >
                   <X className="h-5 w-5 text-slate-600" />
-                </button>
+                </Button>
               </div>
             </div>
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Navbar } from './Navbar';
 export { default as Sidebar } from './Sidebar';
 export { default as DashboardContent } from './DashboardContent';
+export * from './ui';

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type ButtonVariant = 'default' | 'ghost' | 'outline';
+export type ButtonSize = 'default' | 'icon';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', ...props }, ref) => {
+    const base =
+      'inline-flex items-center justify-center rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none';
+    const variants: Record<ButtonVariant, string> = {
+      default: 'bg-blue-600 text-white hover:bg-blue-700',
+      ghost: 'bg-transparent hover:bg-slate-100',
+      outline: 'border border-slate-300 bg-white hover:bg-slate-100',
+    };
+    const sizes: Record<ButtonSize, string> = {
+      default: 'h-10 px-4',
+      icon: 'h-10 w-10',
+    };
+    return (
+      <button
+        ref={ref}
+        className={cn(base, variants[variant], sizes[size], className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border bg-white shadow-sm', className)} {...props} />
+));
+Card.displayName = 'Card';
+
+export type CardHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+export const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-4 border-b', className)} {...props} />
+));
+CardHeader.displayName = 'CardHeader';
+
+export type CardContentProps = React.HTMLAttributes<HTMLDivElement>;
+export const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-4', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+export type CardFooterProps = React.HTMLAttributes<HTMLDivElement>;
+export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-4 border-t', className)} {...props} />
+));
+CardFooter.displayName = 'CardFooter';

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+));
+Input.displayName = 'Input';

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ className, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+));
+Select.displayName = 'Select';

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  pressed?: boolean;
+}
+
+export const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
+  ({ className, pressed, ...props }, ref) => (
+    <button
+      ref={ref}
+      data-pressed={pressed}
+      aria-pressed={pressed}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium transition-colors data-[pressed=true]:bg-blue-600 data-[pressed=true]:text-white',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Toggle.displayName = 'Toggle';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,5 @@
+export * from './Button';
+export * from './Input';
+export * from './Select';
+export * from './Toggle';
+export * from './Card';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add generic `cn` helper
- create `ui` component folder with Button, Input, Select, Toggle, and Card
- re-export UI components
- refactor Navbar, Sidebar, and dashboard/login pages to use new components

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_688aad627c7c83328a64534b1ba5df25