### PR TITLE
Add useToggle hook test

### DIFF
--- a/src/hooks/__tests__/useToggle.test.tsx
+++ b/src/hooks/__tests__/useToggle.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { useToggle } from '../useToggle';
+
+function ToggleComponent() {
+  const { value, toggle } = useToggle();
+  return (
+    <div>
+      <span data-testid="value">{value ? 'true' : 'false'}</span>
+      <button onClick={toggle}>toggle</button>
+    </div>
+  );
+}
+
+describe('useToggle hook', () => {
+  test('toggles value when button clicked', () => {
+    render(<ToggleComponent />);
+    const value = screen.getByTestId('value');
+    expect(value.textContent).toBe('false');
+    fireEvent.click(screen.getByText('toggle'));
+    expect(value.textContent).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
- add basic test for the useToggle hook
- verify Jest configuration uses jsdom

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688aad7bfac083328ab83af353ecdf90