### PR TITLE
Implement export helpers and doc actions feature flag

### DIFF
--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -117,6 +117,8 @@ type PreviewModalState = {
   document: DocumentType | null;
 };
 
+const ENABLE_DOC_ACTIONS = process.env.NEXT_PUBLIC_ENABLE_DOCS_ACTIONS === 'true';
+
 export default function DocumentsPage() {
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [searchTerm, setSearchTerm] = useState('');
@@ -133,6 +135,10 @@ export default function DocumentsPage() {
 
   const handleDownload = async (doc: DocumentType | null) => {
     if (!doc) return;
+    if (!ENABLE_DOC_ACTIONS) {
+      alert('Download feature disabled');
+      return;
+    }
     try {
       const res = await fetch(`/api/documents/${doc.id}`);
       if (!res.ok) throw new Error('Failed to download');
@@ -152,6 +158,10 @@ export default function DocumentsPage() {
 
   const handleShare = async (doc: DocumentType | null) => {
     if (!doc) return;
+    if (!ENABLE_DOC_ACTIONS) {
+      alert('Share feature disabled');
+      return;
+    }
     try {
       const res = await fetch(`/api/documents/${doc.id}`);
       if (!res.ok) throw new Error('Failed to fetch');

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from 'react';
-import { 
+import {
   Download,
   Calendar,
   Filter,
@@ -35,6 +35,7 @@ import {
   Legend
 } from 'recharts';
 import { ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import { exportElementAsPDF, exportElementAsPNG, exportToCSV } from '@/lib/export';
 
 // Mock data for different time periods
 const performanceData = {
@@ -134,51 +135,19 @@ export default function ReportsAnalyticsPage() {
 
   const handleExportPDF = () => {
     if (!reportRef.current) return;
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
-    printWindow.document.write(`<html><body>${reportRef.current.innerHTML}</body></html>`);
-    printWindow.document.close();
-    printWindow.focus();
-    printWindow.print();
-    printWindow.close();
+    exportElementAsPDF(reportRef.current);
     setShowExportMenu(false);
   };
 
   const handleExportImage = () => {
     if (!reportRef.current) return;
-    const svg = reportRef.current.querySelector('svg');
-    if (!svg) return;
-    const svgData = new XMLSerializer().serializeToString(svg);
-    const canvas = document.createElement('canvas');
-    const bbox = svg.getBoundingClientRect();
-    canvas.width = bbox.width;
-    canvas.height = bbox.height;
-    const ctx = canvas.getContext('2d');
-    const img = new window.Image();
-    img.onload = () => {
-      ctx?.drawImage(img, 0, 0);
-      const url = canvas.toDataURL('image/png');
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = 'report.png';
-      link.click();
-    };
-    img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgData)));
+    exportElementAsPNG(reportRef.current, 'report.png');
     setShowExportMenu(false);
   };
 
   const handleExportData = () => {
     if (!currentData) return;
-    const headers = Object.keys(currentData[0]);
-    const rows = currentData.map(row => headers.map(h => row[h as keyof typeof row]).join(','));
-    const csv = [headers.join(','), ...rows].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'data.csv';
-    link.click();
-    window.URL.revokeObjectURL(url);
+    exportToCSV(currentData, 'data.csv');
     setShowExportMenu(false);
   };
 

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,45 @@
+export function exportElementAsPDF(element: HTMLElement) {
+  const printWindow = window.open('', '_blank');
+  if (!printWindow) return;
+  printWindow.document.write(`<html><head><title>Report</title></head><body>${element.innerHTML}</body></html>`);
+  printWindow.document.close();
+  printWindow.focus();
+  printWindow.print();
+  printWindow.close();
+}
+
+export function exportElementAsPNG(element: HTMLElement, fileName = 'report.png') {
+  const svg = element.querySelector('svg');
+  if (!svg) return;
+  const svgData = new XMLSerializer().serializeToString(svg);
+  const canvas = document.createElement('canvas');
+  const bbox = svg.getBoundingClientRect();
+  canvas.width = bbox.width;
+  canvas.height = bbox.height;
+  const ctx = canvas.getContext('2d');
+  const img = new Image();
+  img.onload = () => {
+    ctx?.drawImage(img, 0, 0);
+    const url = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+  img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgData)));
+}
+
+export function exportToCSV<T extends Record<string, unknown>>(data: T[], fileName = 'data.csv') {
+  if (!data.length) return;
+  const headers = Object.keys(data[0]);
+  const rows = data.map(row => headers.map(h => String(row[h] ?? '')).join(','));
+  const csv = [headers.join(','), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add `export.ts` helpers for PDF/image/CSV downloads
- use export helpers in reports page
- guard document download & share with `NEXT_PUBLIC_ENABLE_DOCS_ACTIONS`

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688ab524501c833291e58973666ebdc4