### PR TITLE
Fix lint for unused error parameters

### DIFF
--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -146,6 +146,7 @@ export default function DocumentsPage() {
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
     } catch (err) {
+      console.error(err);
       alert('Download failed');
     }
   };
@@ -171,6 +172,7 @@ export default function DocumentsPage() {
         window.URL.revokeObjectURL(url);
       }
     } catch (err) {
+      console.error(err);
       alert('Share failed');
     }
   };

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request, { params }: { params: { id: string }
       headers: { 'Content-Type': contentType }
     });
   } catch (error) {
+    console.error(error);
     return new NextResponse('File not found', { status: 404 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ export default function LoginPage() {
         setError(data.message || 'Login failed');
       }
     } catch (err) {
+      console.error(err);
       setError('Network error');
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- log caught errors rather than ignoring them

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ab583b89c8332865c7c3aa88cc7c8