### PR TITLE
Refactor pages to use shared UI components

### DIFF
--- a/src/app/(dashboard)/accounts/page.tsx
+++ b/src/app/(dashboard)/accounts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from 'react';
-import { 
+import {
   CreditCard,
   TrendingUp,
   TrendingDown,
@@ -17,6 +17,7 @@ import {
   Home,
   Briefcase
 } from 'lucide-react';
+import { Button, Input, Select } from '@/components/ui';
 
 // Mock account data
 const accountsData = [
@@ -213,27 +214,27 @@ export default function AccountAggregationPage() {
           {/* Search */}
           <div className="relative flex-1 max-w-md">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-5 w-5" />
-            <input
+            <Input
               type="text"
               placeholder="Search accounts..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-2"
             />
           </div>
 
           {/* Account Type Filter */}
           <div className="flex items-center gap-2">
             <Filter className="h-5 w-5 text-slate-500" />
-            <select
+            <Select
               value={selectedType}
               onChange={(e) => setSelectedType(e.target.value)}
-              className="border border-slate-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="px-3 py-2"
             >
               {accountTypes.map(type => (
                 <option key={type} value={type}>{type}</option>
               ))}
-            </select>
+            </Select>
           </div>
         </div>
       </div>
@@ -301,16 +302,16 @@ export default function AccountAggregationPage() {
                 </div>
 
                 <div className="flex items-center space-x-2 ml-4">
-                  <button
+                  <Button
                     onClick={() => handleViewDetails(account)}
                     className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                   >
                     <Eye className="h-4 w-4" />
                     <span>View Details</span>
-                  </button>
-                  <button className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+                  </Button>
+                  <Button variant="ghost" className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
                     <MoreVertical className="h-4 w-4" />
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -334,12 +335,13 @@ export default function AccountAggregationPage() {
             <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
               <div className="flex items-center justify-between mb-6">
                 <h3 className="text-lg font-semibold text-gray-900">Account Details</h3>
-                <button
+                <Button
                   onClick={closeDetails}
+                  variant="ghost"
                   className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
                 >
                   <MoreVertical className="h-5 w-5 text-gray-500 rotate-45" />
-                </button>
+                </Button>
               </div>
 
               <div className="space-y-6">
@@ -396,15 +398,15 @@ export default function AccountAggregationPage() {
                 </div>
 
                 <div className="flex space-x-3 pt-4">
-                  <button
+                  <Button
                     onClick={closeDetails}
                     className="flex-1 bg-gray-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
                   >
                     Close
-                  </button>
-                  <button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors">
+                  </Button>
+                  <Button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors">
                     Manage Account
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 import React, { useState } from 'react';
-import { 
-  FileText, 
-  Download, 
-  Share2, 
+import {
+  FileText,
+  Download,
+  Share2,
   Eye,
   X,
   Calendar,
@@ -20,6 +20,7 @@ import {
   Users,
   LucideProps
 } from 'lucide-react';
+import { Button, Input, Select } from '@/components/ui';
 
 // Mock documents data
 const documentsData = [
@@ -206,12 +207,12 @@ export default function DocumentsPage() {
             {/* Search */}
             <div className="relative flex-1 max-w-md">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-5 w-5" />
-              <input
+              <Input
                 type="text"
                 placeholder="Search documents..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2"
               />
             </div>
 
@@ -219,35 +220,37 @@ export default function DocumentsPage() {
               {/* Category Filter */}
               <div className="flex items-center gap-2">
                 <Filter className="h-5 w-5 text-slate-500" />
-                <select
+                <Select
                   value={selectedCategory}
                   onChange={(e) => setSelectedCategory(e.target.value)}
-                  className="border border-slate-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="px-3 py-2"
                 >
                   {categories.map(category => (
                     <option key={category} value={category}>{category}</option>
                   ))}
-                </select>
+                </Select>
               </div>
 
               {/* View Mode Toggle */}
               <div className="flex items-center bg-slate-100 rounded-lg p-1">
-                <button
+                <Button
                   onClick={() => setViewMode('grid')}
+                  variant="ghost"
                   className={`p-2 rounded-md transition-colors ${
                     viewMode === 'grid' ? 'bg-white shadow-sm text-blue-600' : 'text-slate-500'
                   }`}
                 >
                   <Grid className="h-4 w-4" />
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => setViewMode('list')}
+                  variant="ghost"
                   className={`p-2 rounded-md transition-colors ${
                     viewMode === 'list' ? 'bg-white shadow-sm text-blue-600' : 'text-slate-500'
                   }`}
                 >
                   <List className="h-4 w-4" />
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -265,27 +268,30 @@ export default function DocumentsPage() {
                       <Icon className={`h-6 w-6 ${document.color}`} />
                     </div>
                     <div className="flex items-center space-x-2">
-                      <button
+                      <Button
                         onClick={() => handlePreview(document)}
-                        className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                        variant="ghost"
+                        className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50"
                         title="Preview"
                       >
                         <Eye className="h-4 w-4" />
-                      </button>
-                      <button
+                      </Button>
+                      <Button
                         onClick={() => handleDownload(document)}
-                        className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors"
+                        variant="ghost"
+                        className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50"
                         title="Download"
                       >
                         <Download className="h-4 w-4" />
-                      </button>
-                      <button
+                      </Button>
+                      <Button
                         onClick={() => handleShare(document)}
-                        className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+                        variant="ghost"
+                        className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50"
                         title="Share"
                       >
                         <Share2 className="h-4 w-4" />
-                      </button>
+                      </Button>
                     </div>
                   </div>
                   
@@ -349,27 +355,30 @@ export default function DocumentsPage() {
                         <td className="py-4 px-6 text-slate-600">{document.size}</td>
                         <td className="py-4 px-6">
                           <div className="flex items-center justify-end space-x-2">
-                            <button
+                            <Button
                               onClick={() => handlePreview(document)}
-                              className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                              variant="ghost"
+                              className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50"
                               title="Preview"
                             >
                               <Eye className="h-4 w-4" />
-                            </button>
-                            <button
+                            </Button>
+                            <Button
                               onClick={() => handleDownload(document)}
-                              className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors"
+                              variant="ghost"
+                              className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50"
                               title="Download"
                             >
                               <Download className="h-4 w-4" />
-                            </button>
-                            <button
+                            </Button>
+                            <Button
                               onClick={() => handleShare(document)}
-                              className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+                              variant="ghost"
+                              className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50"
                               title="Share"
                             >
                               <Share2 className="h-4 w-4" />
-                            </button>
+                            </Button>
                           </div>
                         </td>
                       </tr>
@@ -401,12 +410,13 @@ export default function DocumentsPage() {
               <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-semibold text-gray-900">Document Preview</h3>
-                  <button
+                  <Button
                     onClick={closePreview}
+                    variant="ghost"
                     className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
                   >
                     <X className="h-5 w-5 text-gray-500" />
-                  </button>
+                  </Button>
                 </div>
 
                 {previewModal.document && (
@@ -446,20 +456,20 @@ export default function DocumentsPage() {
                     </div>
 
                     <div className="flex space-x-3 pt-4">
-                      <button
+                      <Button
                         onClick={() => handleDownload(previewModal.document)}
                         className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"
                       >
                         <Download className="h-4 w-4" />
                         <span>Download</span>
-                      </button>
-                      <button
+                      </Button>
+                      <Button
                         onClick={() => handleShare(previewModal.document)}
                         className="flex-1 bg-gray-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors flex items-center justify-center space-x-2"
                       >
                         <Share2 className="h-4 w-4" />
                         <span>Share</span>
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 )}

--- a/src/app/(dashboard)/messaging/page.tsx
+++ b/src/app/(dashboard)/messaging/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useRef, useEffect } from 'react';
-import { 
+import {
   Send,
   Search,
   MoreVertical,
@@ -16,6 +16,7 @@ import {
   Filter,
   Star
 } from 'lucide-react';
+import { Button, Input } from '@/components/ui';
 
 // Mock conversations data
 const conversationsData = [
@@ -265,24 +266,24 @@ export default function SecureMessagingPage() {
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-slate-900">Messages</h2>
             <div className="flex items-center space-x-2">
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <Plus className="h-4 w-4" />
-              </button>
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              </Button>
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <Filter className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </div>
           
           {/* Search */}
           <div className="relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-            <input
+            <Input
               type="text"
               placeholder="Search conversations..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+              className="w-full pl-10 pr-4 py-2 text-sm"
             />
           </div>
         </div>
@@ -377,18 +378,18 @@ export default function SecureMessagingPage() {
             </div>
             
             <div className="flex items-center space-x-2">
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <Phone className="h-4 w-4" />
-              </button>
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              </Button>
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <Video className="h-4 w-4" />
-              </button>
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              </Button>
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <Star className="h-4 w-4" />
-              </button>
-              <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+              </Button>
+              <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
                 <MoreVertical className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -432,9 +433,9 @@ export default function SecureMessagingPage() {
         {/* Message Input */}
         <div className="p-4 border-t border-slate-200 bg-white">
           <div className="flex items-end space-x-3">
-            <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+            <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
               <Paperclip className="h-5 w-5" />
-            </button>
+            </Button>
             
             <div className="flex-1 relative">
               <textarea
@@ -447,17 +448,17 @@ export default function SecureMessagingPage() {
               />
             </div>
             
-            <button className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg">
+            <Button variant="ghost" className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100">
               <Smile className="h-5 w-5" />
-            </button>
+            </Button>
             
-            <button
+            <Button
               onClick={handleSendMessage}
               disabled={!newMessage.trim()}
               className="p-3 bg-blue-500 text-white rounded-xl hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <Send className="h-4 w-4" />
-            </button>
+            </Button>
           </div>
           
           <div className="flex items-center justify-between mt-2 text-xs text-slate-500">

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from 'react';
-import { 
+import {
   Download,
   Calendar,
   Filter,
@@ -16,6 +16,7 @@ import {
 
   ChevronDown
 } from 'lucide-react';
+import { Button, Select } from '@/components/ui';
 import { 
   LineChart, 
   Line, 
@@ -196,39 +197,42 @@ export default function ReportsAnalyticsPage() {
           
           {/* Export Actions */}
           <div className="relative">
-            <button
+            <Button
               onClick={() => setShowExportMenu(!showExportMenu)}
               className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
             >
               <Download className="h-4 w-4" />
               <span>Export Report</span>
               <ChevronDown className="h-4 w-4" />
-            </button>
+            </Button>
             
             {showExportMenu && (
               <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-slate-200 z-10">
                 <div className="py-1">
-                  <button
+                  <Button
                     onClick={handleExportPDF}
+                    variant="ghost"
                     className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
                   >
                     <FileText className="h-4 w-4 text-red-500" />
                     <span>Export as PDF</span>
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={handleExportImage}
+                    variant="ghost"
                     className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
                   >
                     <Image className="h-4 w-4 text-green-500" />
                     <span>Export as Image</span>
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={handleExportData}
+                    variant="ghost"
                     className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
                   >
                     <Grid3X3 className="h-4 w-4 text-blue-500" />
                     <span>Export Data (CSV)</span>
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}
@@ -247,9 +251,10 @@ export default function ReportsAnalyticsPage() {
             </div>
             <div className="flex space-x-1 bg-slate-100 rounded-lg p-1">
               {['1M', '3M', '1Y'].map((period) => (
-                <button
+                <Button
                   key={period}
                   onClick={() => setSelectedPeriod(period as '1M' | '3M' | '1Y')}
+                  variant="ghost"
                   className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
                     selectedPeriod === period
                       ? 'bg-white text-slate-900 shadow-sm'
@@ -257,7 +262,7 @@ export default function ReportsAnalyticsPage() {
                   }`}
                 >
                   {period}
-                </button>
+                </Button>
               ))}
             </div>
           </div>
@@ -268,40 +273,42 @@ export default function ReportsAnalyticsPage() {
               <Filter className="h-5 w-5 text-slate-500" />
               <span className="font-medium text-slate-700">Portfolio:</span>
             </div>
-            <select
+            <Select
               value={selectedPortfolio}
               onChange={(e) => setSelectedPortfolio(e.target.value)}
-              className="border border-slate-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="px-3 py-2"
             >
               <option value="all">All Portfolios</option>
               <option value="growth">Growth Portfolio</option>
               <option value="income">Income Portfolio</option>
               <option value="balanced">Balanced Portfolio</option>
-            </select>
+            </Select>
           </div>
 
           {/* Chart Type Selector */}
           <div className="flex items-center space-x-2">
             <span className="font-medium text-slate-700">View:</span>
             <div className="flex space-x-1 bg-slate-100 rounded-lg p-1">
-              <button
+              <Button
                 onClick={() => setChartType('line')}
+                variant="ghost"
                 className={`p-2 rounded-md transition-colors ${
                   chartType === 'line' ? 'bg-white shadow-sm' : 'hover:bg-slate-200'
                 }`}
                 title="Line Chart"
               >
                 <Activity className="h-4 w-4" />
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={() => setChartType('area')}
+                variant="ghost"
                 className={`p-2 rounded-md transition-colors ${
                   chartType === 'area' ? 'bg-white shadow-sm' : 'hover:bg-slate-200'
                 }`}
                 title="Area Chart"
               >
                 <BarChart3 className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from 'react';
-import { 
+import {
   CheckCircle,
   Clock,
   AlertCircle,
@@ -17,6 +17,7 @@ import {
   MoreVertical,
   Check,
 } from 'lucide-react';
+import { Button, Input, Select } from '@/components/ui';
 
 // Mock tasks data
 const tasksData = [
@@ -239,19 +240,21 @@ export default function TasksNotificationsPage() {
               <p className="text-sm text-blue-700">Stay updated with your latest account activities</p>
             </div>
           </div>
-          <button
+          <Button
             onClick={() => setShowNotificationBanner(false)}
+            variant="ghost"
             className="text-blue-500 hover:text-blue-700"
           >
             <X className="h-5 w-5" />
-          </button>
+          </Button>
         </div>
       )}
 
       {/* Tabs */}
       <div className="flex space-x-1 bg-slate-100 rounded-lg p-1 mb-6 w-fit">
-        <button
+        <Button
           onClick={() => setActiveTab('tasks')}
+          variant="ghost"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors relative ${
             activeTab === 'tasks'
               ? 'bg-white text-slate-900 shadow-sm'
@@ -264,9 +267,10 @@ export default function TasksNotificationsPage() {
               {taskCounts.pending}
             </span>
           )}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => setActiveTab('notifications')}
+          variant="ghost"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors relative ${
             activeTab === 'notifications'
               ? 'bg-white text-slate-900 shadow-sm'
@@ -279,7 +283,7 @@ export default function TasksNotificationsPage() {
               {unreadCount}
             </span>
           )}
-        </button>
+        </Button>
       </div>
 
       {/* Tasks Tab */}
@@ -322,38 +326,38 @@ export default function TasksNotificationsPage() {
               {/* Search */}
               <div className="relative flex-1 max-w-md">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <input
+                <Input
                   type="text"
                   placeholder="Search tasks..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                  className="w-full pl-10 pr-4 py-2 text-sm"
                 />
               </div>
 
               {/* Filters */}
               <div className="flex items-center space-x-4">
-                <select
+                <Select
                   value={filterStatus}
                   onChange={(e) => setFilterStatus(e.target.value)}
-                  className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="px-3 py-2 text-sm"
                 >
                   <option value="all">All Status</option>
                   <option value="pending">Pending</option>
                   <option value="in-progress">In Progress</option>
                   <option value="completed">Completed</option>
-                </select>
+                </Select>
 
-                <select
+                <Select
                   value={filterPriority}
                   onChange={(e) => setFilterPriority(e.target.value)}
-                  className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="px-3 py-2 text-sm"
                 >
                   <option value="all">All Priority</option>
                   <option value="high">High</option>
                   <option value="medium">Medium</option>
                   <option value="low">Low</option>
-                </select>
+                </Select>
               </div>
             </div>
           </div>
@@ -397,20 +401,20 @@ export default function TasksNotificationsPage() {
 
                     <div className="flex items-center space-x-2 ml-4">
                       {task.status === 'pending' && (
-                        <button
+                        <Button
                           onClick={() => handleTaskStatusUpdate(task.id, 'in-progress')}
                           className="px-3 py-1 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors text-sm"
                         >
                           Start
-                        </button>
+                        </Button>
                       )}
                       {task.status === 'in-progress' && (
-                        <button
+                        <Button
                           onClick={() => handleTaskStatusUpdate(task.id, 'completed')}
                           className="px-3 py-1 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors text-sm"
                         >
                           Complete
-                        </button>
+                        </Button>
                       )}
                       {task.status === 'completed' && (
                         <div className="flex items-center space-x-1 text-green-600">
@@ -418,9 +422,9 @@ export default function TasksNotificationsPage() {
                           <span className="text-sm font-medium">Done</span>
                         </div>
                       )}
-                      <button className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+                      <Button variant="ghost" className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
                         <MoreVertical className="h-4 w-4" />
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 </div>
@@ -452,12 +456,13 @@ export default function TasksNotificationsPage() {
               )}
             </div>
             {unreadCount > 0 && (
-              <button
+              <Button
                 onClick={handleMarkAllAsRead}
+                variant="ghost"
                 className="text-blue-600 hover:text-blue-800 text-sm font-medium"
               >
                 Mark all as read
-              </button>
+              </Button>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- use shared `Button`, `Input` and `Select` components across dashboard pages
- clean up markup to rely on the new UI helpers

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ab572fc7083329c68277612ca80c3