### PR TITLE
Fix Image icon aliasing in reports page

### DIFF
--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -11,7 +11,7 @@ import {
 
 
   FileText,
-  Image,
+  Image as ImageIcon,
 
 
   ChevronDown
@@ -191,7 +191,7 @@ export default function ReportsAnalyticsPage() {
                     variant="ghost"
                     className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
                   >
-                    <Image className="h-4 w-4 text-green-500" />
+                    <ImageIcon className="h-4 w-4 text-green-500" />
                     <span>Export as Image</span>
                   </Button>
                   <Button


### PR DESCRIPTION
## Summary
- alias lucide-react `Image` icon to `ImageIcon`
- update usage in reports page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688abaa8ec848332bee75d471dc01c6e