### PR TITLE
Add html2canvas and jspdf for report exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- install `html2canvas` and `jspdf` as new dependencies
- update Reports page export handlers to generate PDFs, images and CSV directly in browser

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688abac498a08332bd0b1d9c6b908667