### PR TITLE
Add UI component test and update Jest config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,14 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx|js|jsx)$': [
+      'babel-jest',
+      {
+        presets: ['next/babel'],
+      },
+    ],
   },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+require('@testing-library/jest-dom');

--- a/src/components/ui/__tests__/Input.test.tsx
+++ b/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Input } from '../Input';
+
+describe('Input component', () => {
+  it('renders with placeholder', () => {
+    render(<Input placeholder="email" />);
+    expect(screen.getByPlaceholderText('email')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure jest to use `babel-jest` with Next.js preset and fix alias
- load `@testing-library/jest-dom` via CommonJS in `jest.setup.js`
- add Babel config for tests
- add new Input component test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688abaf953ac83329c1fb6a2724a22ad