### PR TITLE
Fix NextRequest usage in documents API

### DIFF
--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,9 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
-  const { id } = params;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
   const filePath = id === '6'
     ? path.join(process.cwd(), 'public/documents/sample.xlsx')
     : path.join(process.cwd(), 'public/documents/sample.pdf');


### PR DESCRIPTION
## Summary
- update documents API route to use `NextRequest`
- handle promise-based `params` as required by Next.js 15

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aba8975b88332923d6870a02f4814