### PR TITLE
Persist user name in dashboard

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 export async function POST(request: Request) {
   const { email, password } = await request.json();
   if (email === 'demo@bluemarina.com' && password === 'demo123') {
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, name: 'John Anderson' });
   }
   return NextResponse.json({ success: false, message: 'Invalid credentials' }, { status: 401 });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,13 +38,13 @@ export default function LoginPage() {
         body: JSON.stringify({ email, password })
       });
 
+      const data = await res.json();
       if (res.ok) {
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('clientName', 'John Anderson');
+        if (typeof window !== 'undefined' && data.name) {
+          localStorage.setItem('clientName', data.name);
         }
         router.push('/dashboard');
       } else {
-        const data = await res.json();
         setError(data.message || 'Login failed');
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- fetch the user's name from login API and persist it
- return the user's name from the `/login` API endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ac44217348332a6b488958a85a8c3