### PR TITLE
Export DocumentType type

### DIFF
--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -18,9 +18,9 @@ import {
   Shield,
   TrendingUp,
   Users,
-  LucideProps
 } from 'lucide-react';
 import { Button, Input, Select } from '@/components/ui';
+import type { DocumentType } from '@/types';
 
 // Mock documents data
 const documentsData = [
@@ -100,19 +100,6 @@ const documentsData = [
 
 const categories = ['All', 'Reports', 'Contracts', 'Invoices'];
 
-type DocumentType = {
-  id: number;
-  name: string;
-  type: string;
-  category: string;
-  size: string;
-  date: string;
-  description: string;
-  icon: React.ForwardRefExoticComponent<Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>>;
-  color: string;
-  bgColor: string;
-};
-
 type PreviewModalState = {
   isOpen: boolean;
   document: DocumentType | null;
@@ -188,7 +175,8 @@ export default function DocumentsPage() {
     }
   };
 
-  const handlePreview = (document: { id: number; name: string; type: string; category: string; size: string; date: string; description: string; icon: React.ForwardRefExoticComponent<Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>>; color: string; bgColor: string; }) => {
+  const handlePreview = (document: DocumentType | null) => {
+    if (!document) return;
     setPreviewModal({ isOpen: true, document });
   };
 

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -163,9 +163,9 @@ export default function ReportsAnalyticsPage() {
 
   const handleExportData = () => {
     if (!currentData) return;
-    const headers = Object.keys(currentData[0]);
+    const headers = Object.keys(currentData[0]) as Array<keyof typeof currentData[0]>;
     const rows = currentData.map(row =>
-      headers.map(h => String((row as any)[h] ?? '')).join(',')
+      headers.map(h => String(row[h] ?? '')).join(',')
     );
     const csv = [headers.join(','), ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LucideProps } from 'lucide-react';
 
 export interface Task {
   id: number;
@@ -26,4 +27,19 @@ export interface NavItem {
   name: string;
   href: string;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+export interface DocumentType {
+  id: number;
+  name: string;
+  type: string;
+  category: string;
+  size: string;
+  date: string;
+  description: string;
+  icon: React.ForwardRefExoticComponent<
+    Omit<LucideProps, 'ref'> & React.RefAttributes<SVGSVGElement>
+  >;
+  color: string;
+  bgColor: string;
 }


### PR DESCRIPTION
## Summary
- move `DocumentType` to the global types module
- update document actions to accept `DocumentType | null`
- fix lint issue in reports page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ac48a7e0483329c2ba07fc187c8ad