### PR TITLE
Fix tooltip typings

### DIFF
--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -35,7 +35,11 @@ import {
   ComposedChart,
   Legend
 } from 'recharts';
-import { ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import {
+  ValueType,
+  NameType,
+  TooltipProps
+} from 'recharts/types/component/DefaultTooltipContent';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 
@@ -164,8 +168,8 @@ export default function ReportsAnalyticsPage() {
   const handleExportData = () => {
     if (!currentData) return;
     const headers = Object.keys(currentData[0]);
-    const rows = currentData.map(row =>
-      headers.map(h => String((row as any)[h] ?? '')).join(',')
+    const rows = currentData.map((row) =>
+      headers.map((h) => String((row as Record<string, unknown>)[h] ?? '')).join(',')
     );
     const csv = [headers.join(','), ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
@@ -336,16 +340,16 @@ export default function ReportsAnalyticsPage() {
                   fontSize={12}
                   tickFormatter={(value) => `$${(value / 1000000).toFixed(1)}M`}
                 />
-                <Tooltip
-                  formatter={(value, name) => [
-                    formatCurrency(value),
-                    name === 'portfolio' ? 'Portfolio' : 'Benchmark'
-                  ]}
-                  labelStyle={{ color: '#1e293b' }}
-                  contentStyle={{ 
-                    backgroundColor: 'white', 
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '8px'
+                  <Tooltip
+                    formatter={(value: ValueType, name: NameType) => [
+                      formatCurrency(value),
+                      name === 'portfolio' ? 'Portfolio' : 'Benchmark'
+                    ]}
+                    labelStyle={{ color: '#1e293b' }}
+                    contentStyle={{
+                      backgroundColor: 'white',
+                      border: '1px solid #e2e8f0',
+                      borderRadius: '8px'
                   }}
                 />
                 <Line
@@ -374,12 +378,12 @@ export default function ReportsAnalyticsPage() {
                   fontSize={12}
                   tickFormatter={(value) => `$${(value / 1000000).toFixed(1)}M`}
                 />
-                <Tooltip
-                  formatter={(value, name) => [
-                    formatCurrency(value),
-                    name === 'portfolio' ? 'Portfolio' : 'Benchmark'
-                  ]}
-                />
+                  <Tooltip
+                    formatter={(value: ValueType, name: NameType) => [
+                      formatCurrency(value),
+                      name === 'portfolio' ? 'Portfolio' : 'Benchmark'
+                    ]}
+                  />
                 <Area
                   type="monotone"
                   dataKey="portfolio"
@@ -424,7 +428,11 @@ export default function ReportsAnalyticsPage() {
                   ))}
                 </Pie>
                 <Tooltip
-                  formatter={(value, name, props) => [
+                  formatter={(
+                    value: ValueType,
+                    name: NameType,
+                    props: TooltipProps<ValueType, NameType>
+                  ) => [
                     `${value}% (${formatCurrency(props.payload.amount)})`,
                     props.payload.name
                   ]}
@@ -466,12 +474,12 @@ export default function ReportsAnalyticsPage() {
                   fontSize={11}
                   width={80}
                 />
-                <Tooltip
-                  formatter={(value, name) => [
-                    name === 'allocation' ? `${value}%` : `${formatPercent(value)}`,
-                    name === 'allocation' ? 'Allocation' : 'Performance'
-                  ]}
-                />
+                  <Tooltip
+                    formatter={(value: ValueType, name: NameType) => [
+                      name === 'allocation' ? `${value}%` : `${formatPercent(value)}`,
+                      name === 'allocation' ? 'Allocation' : 'Performance'
+                    ]}
+                  />
                 <Bar dataKey="allocation" fill="#0ea5e9" />
                 <Bar dataKey="performance" fill="#14b8a6" />
               </BarChart>
@@ -491,7 +499,9 @@ export default function ReportsAnalyticsPage() {
                 <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
                 <XAxis dataKey="month" stroke="#64748b" fontSize={12} />
                 <YAxis stroke="#64748b" fontSize={12} />
-                <Tooltip formatter={(value) => [formatCurrency(value)]} />
+                <Tooltip
+                  formatter={(value: ValueType) => [formatCurrency(value)]}
+                />
                 <Legend />
                 <Bar dataKey="dividends" stackId="a" fill="#0ea5e9" name="Dividends" />
                 <Bar dataKey="interest" stackId="a" fill="#14b8a6" name="Interest" />

--- a/src/types/recharts.d.ts
+++ b/src/types/recharts.d.ts
@@ -1,0 +1,5 @@
+declare module 'recharts/types/component/DefaultTooltipContent' {
+  export type ValueType = number | string | Array<number | string>;
+  export type NameType = number | string;
+  export type TooltipProps<TValue extends ValueType, TName extends NameType> = import('recharts/types/component/DefaultTooltipContent').Props<TValue, TName>;
+}


### PR DESCRIPTION
## Summary
- import Tooltip type declarations from Recharts
- apply explicit types to tooltip formatter callbacks
- provide compatibility typings for TooltipProps
- remove `any` cast when exporting CSV

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ac433509083328ce2e10cba12cda5