### PR TITLE
Add concise README and fix lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,43 @@
 # Client Portal Demo
 
-This project is a simple client dashboard built with **Next.js** and TypeScript. After logging in, users land on a dashboard with quick links to sections for accounts, documents, messages, reports and tasks. Styling is handled with Tailwind CSS and components are tested with Jest.
+A sample client dashboard built with **Next.js**, TypeScript and Tailwind CSS. Users log in and access sections for accounts, documents, messages, reports and tasks.
 
 ## Folder Structure
 
-```
-src/
-  app/             # Next.js app router pages and layouts
-  components/      # Reusable React components
-  context/         # React context for global state
-  hooks/           # Custom hooks and their tests
-  lib/             # Helper utilities (auth, etc.)
-  types/           # Shared TypeScript types
-public/            # Static assets served by Next.js
-```
+- `src/app` – Next.js routes and layouts
+- `src/components` – shared UI components
+- `src/context` – React context for global state
+- `src/hooks` – custom hooks with tests
+- `src/lib` – helper utilities
+- `src/types` – shared TypeScript types
+- `public` – static assets served by Next.js
 
-## Setup
+## Getting Started
 
-Install dependencies and start the development server:
+Install dependencies and run the development server:
 
 ```bash
 npm install
 npm run dev
 ```
 
-### Linting
+### Lint
 
 ```bash
 npm run lint
 ```
 
-### Running Tests
+### Tests
 
 ```bash
 npm test
 ```
 
-### Production Build
-
-Create the optimized build output:
+### Build
 
 ```bash
 npm run build
 ```
-
-## Deployment
-
-After running `npm run build`, start the server with:
-
-```bash
-npm start
-```
-
-The application can also be deployed to any platform that supports Node.js, such as Vercel or a traditional hosting provider.
 
 ## License
 

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -165,7 +165,7 @@ export default function ReportsAnalyticsPage() {
     if (!currentData) return;
     const headers = Object.keys(currentData[0]);
     const rows = currentData.map(row =>
-      headers.map(h => String((row as any)[h] ?? '')).join(',')
+      headers.map(h => String((row as Record<string, unknown>)[h] ?? '')).join(',')
     );
     const csv = [headers.join(','), ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });


### PR DESCRIPTION
## Summary
- rewrite README to be concise and include folder breakdown and commands
- avoid an `any` type in reports page

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ac64bf7f083328dc46fde63d7f0ac