### PR TITLE
feat: add theme provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,14 +4,17 @@ import "@/app/globals.css";
 import { ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
+import { ThemeProvider } from "next-themes";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap React Query provider with next-themes ThemeProvider in root layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f5be36808332915eba1d89ae5679