### PR TITLE
Enable dark mode via class

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind config

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Conversion of type 'PerformanceRecord' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other)*
- `npx tailwindcss -i ./src/app/globals.css -o ./public/tailwind.css`


------
https://chatgpt.com/codex/tasks/task_e_6893f5e34660833286acfe9c3b9399b7