### PR TITLE
Add Zod validation schemas and helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "react-hook-form": "^7.51.3",
+    "@hookform/resolvers": "^3.6.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,32 @@
+import { z, ZodError } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+export const messageSchema = z.object({
+  message: z.string().min(1, 'Message is required'),
+});
+
+export const taskSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().min(1, 'Description is required'),
+  priority: z.enum(['low', 'medium', 'high']),
+  status: z.enum(['pending', 'in-progress', 'completed']).default('pending'),
+  dueDate: z.coerce.date({ invalid_type_error: 'Due date is required' }),
+});
+
+export type LoginForm = z.infer<typeof loginSchema>;
+export type MessageForm = z.infer<typeof messageSchema>;
+export type TaskForm = z.infer<typeof taskSchema>;
+
+export function formatZodErrors<T>(error: ZodError<T>) {
+  return error.issues.reduce<Record<string, string>>((acc, issue) => {
+    const path = issue.path.join('.');
+    if (!acc[path]) {
+      acc[path] = issue.message;
+    }
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
## Summary
- add login, message, and task Zod schemas with reusable error formatting helper
- declare react-hook-form, @hookform/resolvers and zod dependencies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894003578048332a630159d901b52a8