### PR TITLE
Use react-hook-form with zod for messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "react-hook-form": "^7.51.2",
+    "@hookform/resolvers": "^3.9.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add react-hook-form, zod, and resolver dependencies
- validate messaging input with zod schema and react-hook-form
- show validation errors and clear input after sending

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68940059223883328e81c3c6430f24f2