### PR TITLE
Add sign out controls to navigation

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
 "use client";
 import React from 'react';
-import { Bell, User, Menu, Sun, Moon } from 'lucide-react';
+import { Bell, User, Menu, Sun, Moon, LogOut } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { signOut } from 'next-auth/react';
 import { Button } from '@/components/ui';
 import { useClient } from '@/context/ClientContext';
 
@@ -59,6 +60,15 @@ export default function Navbar({
                   <span className="text-sm">Light</span>
                 </>
               )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+              onClick={() => signOut({ callbackUrl: '/' })}
+              aria-label="Sign out"
+            >
+              <LogOut className="h-5 w-5" />
             </Button>
             <div className="hidden md:flex items-center space-x-2">
               <div className="bg-blue-100 dark:bg-blue-900 p-2 rounded-full">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { 
+import {
   Waves,
   Home,
   FileText,
@@ -11,10 +11,12 @@ import {
   CheckSquare,
   ChevronLeft,
   User,
+  LogOut,
   X
 } from 'lucide-react';
 import { useClient } from '@/context/ClientContext';
 import { Button } from '@/components/ui';
+import { signOut } from 'next-auth/react';
 
 // Navigation items
 const navItems = [
@@ -125,6 +127,14 @@ export default function Sidebar({
                 <p className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">{clientName}</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">Premium Client</p>
               </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => signOut({ callbackUrl: '/' })}
+                aria-label="Sign out"
+              >
+                <LogOut className="h-5 w-5 text-slate-600 dark:text-slate-200" />
+              </Button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- add sign out button in navbar actions
- add sign out control in sidebar user section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68940cdfc9d88332b610892ef967003c