### PR TITLE
feat: add dark mode support

### DIFF
--- a/src/app/(dashboard)/accounts/page.tsx
+++ b/src/app/(dashboard)/accounts/page.tsx
@@ -87,20 +87,20 @@ export default function AccountAggregationPage() {
   };
 
   return (
-    <div className="p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen p-4 sm:p-6 lg:p-8 text-slate-900 dark:text-slate-100">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-slate-900 mb-2">Account Aggregation</h1>
-        <p className="text-slate-600">Overview of all your accounts and portfolios</p>
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-2">Account Aggregation</h1>
+        <p className="text-slate-600 dark:text-slate-400">Overview of all your accounts and portfolios</p>
       </div>
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-slate-600 text-sm font-medium">Total Balance</p>
-              <p className="text-2xl md:text-3xl font-bold text-slate-900">{formatCurrency(totalBalance)}</p>
+              <p className="text-slate-600 dark:text-slate-400 text-sm font-medium">Total Balance</p>
+              <p className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-slate-100">{formatCurrency(totalBalance)}</p>
             </div>
             <div className="bg-blue-100 p-3 rounded-full">
               <DollarSign className="h-6 w-6 text-blue-600" />
@@ -108,11 +108,11 @@ export default function AccountAggregationPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-slate-600 text-sm font-medium">Total Change</p>
-              <p className={`text-2xl md:text-3xl font-bold ${totalChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              <p className="text-slate-600 dark:text-slate-400 text-sm font-medium">Total Change</p>
+              <p className={`text-2xl md:text-3xl font-bold ${totalChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>\
                 {formatCurrency(totalChange)}
               </p>
             </div>
@@ -126,11 +126,11 @@ export default function AccountAggregationPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-slate-600 text-sm font-medium">Performance</p>
-              <p className={`text-2xl md:text-3xl font-bold ${totalChangePercent >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              <p className="text-slate-600 dark:text-slate-400 text-sm font-medium">Performance</p>
+              <p className={`text-2xl md:text-3xl font-bold ${totalChangePercent >= 0 ? 'text-green-600' : 'text-red-600'}`}>\
                 {formatPercent(totalChangePercent)}
               </p>
             </div>
@@ -142,27 +142,27 @@ export default function AccountAggregationPage() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-6">
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 mb-6">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
           {/* Search */}
           <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-5 w-5" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-5 w-5" />
             <Input
               type="text"
               placeholder="Search accounts..."
               value={searchTerm}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2"
+              className="w-full pl-10 pr-4 py-2 dark:bg-slate-900 dark:text-slate-100"
             />
           </div>
 
           {/* Account Type Filter */}
           <div className="flex items-center gap-2">
-            <Filter className="h-5 w-5 text-slate-500" />
+            <Filter className="h-5 w-5 text-slate-500 dark:text-slate-400" />
             <Select
               value={selectedType}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSelectedType(e.target.value)}
-              className="px-3 py-2"
+              className="px-3 py-2 dark:bg-slate-900 dark:text-slate-100"
             >
               {accountTypes.map(type => (
                 <option key={type} value={type}>{type}</option>
@@ -177,16 +177,16 @@ export default function AccountAggregationPage() {
         {filteredAccounts.map((account) => {
           const Icon = iconMap[account.icon as keyof typeof iconMap];
           return (
-            <div key={account.id} className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 hover:shadow-md transition-shadow">
+            <div key={account.id} className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 hover:shadow-md transition-shadow">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-4 flex-1">
                   <div className={`p-3 rounded-lg ${account.bgColor}`}>
                     <Icon className={`h-6 w-6 ${account.color}`} />
                   </div>
-                  
+
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between mb-2">
-                      <h3 className="font-semibold text-slate-900 truncate">{account.name}</h3>
+                      <h3 className="font-semibold text-slate-900 dark:text-slate-100 truncate">{account.name}</h3>
                       <div className="flex items-center space-x-2">
                         <span className={`px-2 py-1 rounded-full text-xs font-medium ${
                           account.status === 'Active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
@@ -195,18 +195,18 @@ export default function AccountAggregationPage() {
                         </span>
                       </div>
                     </div>
-                    
+
                     <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
                       <div>
-                        <p className="text-slate-500">Account</p>
-                        <p className="font-medium text-slate-900">{account.accountNumber}</p>
+                        <p className="text-slate-500 dark:text-slate-400">Account</p>
+                        <p className="font-medium text-slate-900 dark:text-slate-100">{account.accountNumber}</p>
                       </div>
                       <div>
-                        <p className="text-slate-500">Balance</p>
-                        <p className="font-bold text-lg text-slate-900">{formatCurrency(account.balance)}</p>
+                        <p className="text-slate-500 dark:text-slate-400">Balance</p>
+                        <p className="font-bold text-lg text-slate-900 dark:text-slate-100">{formatCurrency(account.balance)}</p>
                       </div>
                       <div>
-                        <p className="text-slate-500">Change</p>
+                        <p className="text-slate-500 dark:text-slate-400">Change</p>
                         <div className="flex items-center space-x-1">
                           {account.change >= 0 ? (
                             <ArrowUpRight className="h-4 w-4 text-green-600" />
@@ -219,14 +219,14 @@ export default function AccountAggregationPage() {
                         </div>
                       </div>
                       <div>
-                        <p className="text-slate-500">YTD Return</p>
+                        <p className="text-slate-500 dark:text-slate-400">YTD Return</p>
                         <p className="font-medium text-green-600">+{account.ytdReturn}%</p>
                       </div>
                     </div>
 
                     <div className="mt-3 flex flex-wrap gap-2">
                       {account.assetTypes.map((asset, index) => (
-                        <span key={index} className="px-2 py-1 bg-slate-100 text-slate-700 rounded-md text-xs font-medium">
+                        <span key={index} className="px-2 py-1 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-md text-xs font-medium">
                           {asset}
                         </span>
                       ))}
@@ -242,7 +242,7 @@ export default function AccountAggregationPage() {
                     <Eye className="h-4 w-4" />
                     <span>View Details</span>
                   </Button>
-                  <Button variant="ghost" className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+                  <Button variant="ghost" className="p-2 text-slate-400 dark:text-slate-300 hover:text-slate-600 dark:hover:text-slate-200 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700">
                     <MoreVertical className="h-4 w-4" />
                   </Button>
                 </div>
@@ -256,8 +256,8 @@ export default function AccountAggregationPage() {
       {filteredAccounts.length === 0 && (
         <div className="text-center py-12">
           <CreditCard className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-          <h3 className="text-lg font-semibold text-slate-900 mb-2">No accounts found</h3>
-          <p className="text-slate-600">Try adjusting your search or filter criteria.</p>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">No accounts found</h3>
+          <p className="text-slate-600 dark:text-slate-400">Try adjusting your search or filter criteria.</p>
         </div>
       )}
 
@@ -265,15 +265,15 @@ export default function AccountAggregationPage() {
       {selectedAccount && (
         <div className="fixed inset-0 z-50 overflow-y-auto bg-black bg-opacity-50">
           <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-            <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+            <div className="inline-block align-bottom bg-white dark:bg-slate-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
               <div className="flex items-center justify-between mb-6">
-                <h3 className="text-lg font-semibold text-gray-900">Account Details</h3>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">Account Details</h3>
                 <Button
                   onClick={closeDetails}
                   variant="ghost"
-                  className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                  className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
                 >
-                  <MoreVertical className="h-5 w-5 text-gray-500 rotate-45" />
+                  <MoreVertical className="h-5 w-5 text-gray-500 dark:text-slate-400 rotate-45" />
                 </Button>
               </div>
 
@@ -283,45 +283,45 @@ export default function AccountAggregationPage() {
                     {SelectedIcon && <SelectedIcon className={`h-8 w-8 ${selectedAccount.color}`} />}
                   </div>
                   <div>
-                    <h4 className="font-semibold text-gray-900">{selectedAccount.name}</h4>
-                    <p className="text-sm text-gray-500">{selectedAccount.type} • {selectedAccount.accountNumber}</p>
+                    <h4 className="font-semibold text-gray-900 dark:text-slate-100">{selectedAccount.name}</h4>
+                    <p className="text-sm text-gray-500 dark:text-slate-400">{selectedAccount.type} • {selectedAccount.accountNumber}</p>
                   </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-600 mb-1">Current Balance</p>
-                    <p className="text-xl font-bold text-gray-900">{formatCurrency(selectedAccount.balance)}</p>
+                  <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-300 mb-1">Current Balance</p>
+                    <p className="text-xl font-bold text-gray-900 dark:text-slate-100">{formatCurrency(selectedAccount.balance)}</p>
                   </div>
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-600 mb-1">Change</p>
-                    <p className={`text-xl font-bold ${selectedAccount.change >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-300 mb-1">Change</p>
+                    <p className={`text-xl font-bold ${selectedAccount.change >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
                       {formatCurrency(selectedAccount.change)}
                     </p>
                   </div>
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-600 mb-1">Risk Level</p>
-                    <p className="text-lg font-semibold text-gray-900">{selectedAccount.riskLevel}</p>
+                  <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-300 mb-1">Risk Level</p>
+                    <p className="text-lg font-semibold text-gray-900 dark:text-slate-100">{selectedAccount.riskLevel}</p>
                   </div>
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-600 mb-1">YTD Return</p>
+                  <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-300 mb-1">YTD Return</p>
                     <p className="text-lg font-semibold text-green-600">+{selectedAccount.ytdReturn}%</p>
                   </div>
                 </div>
 
                 <div>
-                  <p className="text-sm text-gray-600 mb-2">Asset Types</p>
+                  <p className="text-sm text-gray-600 dark:text-slate-300 mb-2">Asset Types</p>
                   <div className="flex flex-wrap gap-2">
                     {selectedAccount.assetTypes.map((asset, index) => (
-                      <span key={index} className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
+                      <span key={index} className="px-3 py-1 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100 rounded-full text-sm font-medium">
                         {asset}
                       </span>
                     ))}
                   </div>
                 </div>
 
-                <div className="pt-4 border-t border-gray-200">
-                  <p className="text-sm text-gray-500">
+                <div className="pt-4 border-t border-gray-200 dark:border-slate-600">
+                  <p className="text-sm text-gray-500 dark:text-slate-400">
                     Last updated: {new Date(selectedAccount.lastUpdated).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: 'long',
@@ -333,7 +333,7 @@ export default function AccountAggregationPage() {
                 <div className="flex space-x-3 pt-4">
                   <Button
                     onClick={closeDetails}
-                    className="flex-1 bg-gray-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
+                    className="flex-1 bg-gray-600 dark:bg-slate-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 dark:hover:bg-slate-700 transition-colors"
                   >
                     Close
                   </Button>

--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -139,37 +139,37 @@ export default function DocumentsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 p-4 sm:p-6 lg:p-8">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-slate-900 mb-2">Documents</h1>
-          <p className="text-slate-600">Access and manage your important financial documents</p>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-2">Documents</h1>
+          <p className="text-slate-600 dark:text-slate-400">Access and manage your important financial documents</p>
         </div>
 
         {/* Filters and Search */}
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-6">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 mb-6">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
             {/* Search */}
             <div className="relative flex-1 max-w-md">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-5 w-5" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-5 w-5" />
               <Input
                 type="text"
                 placeholder="Search documents..."
                 value={searchTerm}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2"
+                className="w-full pl-10 pr-4 py-2 dark:bg-slate-900 dark:text-slate-100"
               />
             </div>
 
             <div className="flex items-center gap-4">
               {/* Category Filter */}
               <div className="flex items-center gap-2">
-                <Filter className="h-5 w-5 text-slate-500" />
+                <Filter className="h-5 w-5 text-slate-500 dark:text-slate-400" />
                 <Select
                   value={selectedCategory}
                     onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSelectedCategory(e.target.value)}
-                  className="px-3 py-2"
+                  className="px-3 py-2 dark:bg-slate-900 dark:text-slate-100"
                 >
                   {categories.map(category => (
                     <option key={category} value={category}>{category}</option>
@@ -178,12 +178,12 @@ export default function DocumentsPage() {
               </div>
 
               {/* View Mode Toggle */}
-              <div className="flex items-center bg-slate-100 rounded-lg p-1">
+              <div className="flex items-center bg-slate-100 dark:bg-slate-700 rounded-lg p-1">
                 <Button
                   onClick={() => setViewMode('grid')}
                   variant="ghost"
                   className={`p-2 rounded-md transition-colors ${
-                    viewMode === 'grid' ? 'bg-white shadow-sm text-blue-600' : 'text-slate-500'
+                    viewMode === 'grid' ? 'bg-white dark:bg-slate-800 shadow-sm text-blue-600' : 'text-slate-500 dark:text-slate-400'
                   }`}
                 >
                   <Grid className="h-4 w-4" />
@@ -192,7 +192,7 @@ export default function DocumentsPage() {
                   onClick={() => setViewMode('list')}
                   variant="ghost"
                   className={`p-2 rounded-md transition-colors ${
-                    viewMode === 'list' ? 'bg-white shadow-sm text-blue-600' : 'text-slate-500'
+                    viewMode === 'list' ? 'bg-white dark:bg-slate-800 shadow-sm text-blue-600' : 'text-slate-500 dark:text-slate-400'
                   }`}
                 >
                   <List className="h-4 w-4" />
@@ -208,7 +208,7 @@ export default function DocumentsPage() {
             {filteredDocuments.map((document) => {
               const Icon = iconMap[document.icon as keyof typeof iconMap];
               return (
-                <div key={document.id} className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 hover:shadow-md transition-shadow">
+                <div key={document.id} className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 hover:shadow-md transition-shadow">
                   <div className="flex items-start justify-between mb-4">
                     <div className={`p-3 rounded-lg ${document.bgColor}`}>
                       <Icon className={`h-6 w-6 ${document.color}`} />
@@ -217,7 +217,7 @@ export default function DocumentsPage() {
                       <Button
                         onClick={() => handlePreview(document)}
                         variant="ghost"
-                        className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50"
+                        className="p-2 text-slate-500 dark:text-slate-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-700"
                         title="Preview"
                       >
                         <Eye className="h-4 w-4" />
@@ -225,7 +225,7 @@ export default function DocumentsPage() {
                       <Button
                         onClick={() => handleDownload(document)}
                         variant="ghost"
-                        className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50"
+                        className="p-2 text-slate-500 dark:text-slate-400 hover:text-green-600 hover:bg-green-50 dark:hover:bg-slate-700"
                         title="Download"
                       >
                         <Download className="h-4 w-4" />
@@ -233,18 +233,18 @@ export default function DocumentsPage() {
                       <Button
                         onClick={() => handleShare(document)}
                         variant="ghost"
-                        className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50"
+                        className="p-2 text-slate-500 dark:text-slate-400 hover:text-purple-600 hover:bg-purple-50 dark:hover:bg-slate-700"
                         title="Share"
                       >
                         <Share2 className="h-4 w-4" />
                       </Button>
                     </div>
                   </div>
-                  
-                  <h3 className="font-semibold text-slate-900 mb-2 line-clamp-2">{document.name}</h3>
-                  <p className="text-sm text-slate-600 mb-4 line-clamp-2">{document.description}</p>
-                  
-                  <div className="flex items-center justify-between text-sm text-slate-500">
+
+                  <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-2 line-clamp-2">{document.name}</h3>
+                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-4 line-clamp-2">{document.description}</p>
+
+                  <div className="flex items-center justify-between text-sm text-slate-500 dark:text-slate-400">
                     <div className="flex items-center space-x-4">
                       <span className="flex items-center">
                         <Calendar className="h-4 w-4 mr-1" />
@@ -255,7 +255,7 @@ export default function DocumentsPage() {
                         {document.size}
                       </span>
                     </div>
-                    <span className="px-2 py-1 bg-slate-100 rounded-full text-xs font-medium">
+                    <span className="px-2 py-1 bg-slate-100 dark:bg-slate-700 rounded-full text-xs font-medium text-slate-700 dark:text-slate-300">
                       {document.category}
                     </span>
                   </div>
@@ -264,47 +264,47 @@ export default function DocumentsPage() {
             })}
           </div>
         ) : (
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+          <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-slate-50 border-b border-slate-200">
+                <thead className="bg-slate-50 dark:bg-slate-700 border-b border-slate-200 dark:border-slate-700">
                   <tr>
-                    <th className="text-left py-4 px-6 font-semibold text-slate-900">Document</th>
-                    <th className="text-left py-4 px-6 font-semibold text-slate-900">Category</th>
-                    <th className="text-left py-4 px-6 font-semibold text-slate-900">Date</th>
-                    <th className="text-left py-4 px-6 font-semibold text-slate-900">Size</th>
-                    <th className="text-right py-4 px-6 font-semibold text-slate-900">Actions</th>
+                    <th className="text-left py-4 px-6 font-semibold text-slate-900 dark:text-slate-100">Document</th>
+                    <th className="text-left py-4 px-6 font-semibold text-slate-900 dark:text-slate-100">Category</th>
+                    <th className="text-left py-4 px-6 font-semibold text-slate-900 dark:text-slate-100">Date</th>
+                    <th className="text-left py-4 px-6 font-semibold text-slate-900 dark:text-slate-100">Size</th>
+                    <th className="text-right py-4 px-6 font-semibold text-slate-900 dark:text-slate-100">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {filteredDocuments.map((document) => {
                     const Icon = iconMap[document.icon as keyof typeof iconMap];
                     return (
-                      <tr key={document.id} className="border-b border-slate-100 hover:bg-slate-50">
+                      <tr key={document.id} className="border-b border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700">
                         <td className="py-4 px-6">
                           <div className="flex items-center space-x-3">
                             <div className={`p-2 rounded-lg ${document.bgColor}`}>
                               <Icon className={`h-5 w-5 ${document.color}`} />
                             </div>
                             <div>
-                              <h4 className="font-medium text-slate-900">{document.name}</h4>
-                              <p className="text-sm text-slate-500">{document.description}</p>
+                              <h4 className="font-medium text-slate-900 dark:text-slate-100">{document.name}</h4>
+                              <p className="text-sm text-slate-500 dark:text-slate-400">{document.description}</p>
                             </div>
                           </div>
                         </td>
                         <td className="py-4 px-6">
-                          <span className="px-3 py-1 bg-slate-100 rounded-full text-sm font-medium text-slate-700">
+                          <span className="px-3 py-1 bg-slate-100 dark:bg-slate-700 rounded-full text-sm font-medium text-slate-700 dark:text-slate-300">
                             {document.category}
                           </span>
                         </td>
-                        <td className="py-4 px-6 text-slate-600">{formatDate(document.date)}</td>
-                        <td className="py-4 px-6 text-slate-600">{document.size}</td>
+                        <td className="py-4 px-6 text-slate-600 dark:text-slate-400">{formatDate(document.date)}</td>
+                        <td className="py-4 px-6 text-slate-600 dark:text-slate-400">{document.size}</td>
                         <td className="py-4 px-6">
                           <div className="flex items-center justify-end space-x-2">
                             <Button
                               onClick={() => handlePreview(document)}
                               variant="ghost"
-                              className="p-2 text-slate-500 hover:text-blue-600 hover:bg-blue-50"
+                              className="p-2 text-slate-500 dark:text-slate-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-700"
                               title="Preview"
                             >
                               <Eye className="h-4 w-4" />
@@ -312,7 +312,7 @@ export default function DocumentsPage() {
                             <Button
                               onClick={() => handleDownload(document)}
                               variant="ghost"
-                              className="p-2 text-slate-500 hover:text-green-600 hover:bg-green-50"
+                              className="p-2 text-slate-500 dark:text-slate-400 hover:text-green-600 hover:bg-green-50 dark:hover:bg-slate-700"
                               title="Download"
                             >
                               <Download className="h-4 w-4" />
@@ -320,7 +320,7 @@ export default function DocumentsPage() {
                             <Button
                               onClick={() => handleShare(document)}
                               variant="ghost"
-                              className="p-2 text-slate-500 hover:text-purple-600 hover:bg-purple-50"
+                              className="p-2 text-slate-500 dark:text-slate-400 hover:text-purple-600 hover:bg-purple-50 dark:hover:bg-slate-700"
                               title="Share"
                             >
                               <Share2 className="h-4 w-4" />
@@ -340,8 +340,8 @@ export default function DocumentsPage() {
         {filteredDocuments.length === 0 && (
           <div className="text-center py-12">
             <File className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-slate-900 mb-2">No documents found</h3>
-            <p className="text-slate-600">Try adjusting your search or filter criteria.</p>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">No documents found</h3>
+            <p className="text-slate-600 dark:text-slate-400">Try adjusting your search or filter criteria.</p>
           </div>
         )}
 
@@ -353,15 +353,15 @@ export default function DocumentsPage() {
                 <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
               </div>
 
-              <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+              <div className="inline-block align-bottom bg-white dark:bg-slate-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-lg font-semibold text-gray-900">Document Preview</h3>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">Document Preview</h3>
                   <Button
                     onClick={closePreview}
                     variant="ghost"
-                    className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                    className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
                   >
-                    <X className="h-5 w-5 text-gray-500" />
+                    <X className="h-5 w-5 text-gray-500 dark:text-slate-400" />
                   </Button>
                 </div>
 
@@ -375,18 +375,18 @@ export default function DocumentsPage() {
                         })()}
                       </div>
                       <div>
-                        <h4 className="font-medium text-gray-900">{previewModal.document.name}</h4>
-                        <p className="text-sm text-gray-500">{previewModal.document.category} • {previewModal.document.size}</p>
+                        <h4 className="font-medium text-gray-900 dark:text-slate-100">{previewModal.document.name}</h4>
+                        <p className="text-sm text-gray-500 dark:text-slate-400">{previewModal.document.category} • {previewModal.document.size}</p>
                       </div>
                     </div>
 
-                    <div className="bg-gray-50 rounded-lg p-4">
-                      <p className="text-sm text-gray-700 mb-2">Description:</p>
-                      <p className="text-gray-900">{previewModal.document.description}</p>
+                    <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                      <p className="text-sm text-gray-700 dark:text-slate-300 mb-2">Description:</p>
+                      <p className="text-gray-900 dark:text-slate-100">{previewModal.document.description}</p>
                     </div>
 
-                    <div className="bg-gray-50 rounded-lg p-4">
-                      <p className="text-sm text-gray-700 mb-2">Document Details:</p>
+                    <div className="bg-gray-50 dark:bg-slate-700 rounded-lg p-4">
+                      <p className="text-sm text-gray-700 dark:text-slate-300 mb-2">Document Details:</p>
                       <div className="space-y-1 text-sm">
                         <p><span className="font-medium">Date:</span> {formatDate(previewModal.document.date)}</p>
                         <p><span className="font-medium">Type:</span> {previewModal.document.type}</p>
@@ -394,13 +394,13 @@ export default function DocumentsPage() {
                       </div>
                     </div>
 
-                    <div className="border border-gray-200 rounded-lg p-4 bg-white text-center">
+                    <div className="border border-gray-200 dark:border-slate-600 rounded-lg p-4 bg-white dark:bg-slate-800 text-center">
                       <object
                         data={`/api/documents/${previewModal.document.id}`}
                         type="application/pdf"
                         className="w-full h-96"
                       >
-                        <p className="text-gray-600">Preview unavailable.</p>
+                        <p className="text-gray-600 dark:text-slate-400">Preview unavailable.</p>
                       </object>
                     </div>
 
@@ -414,7 +414,7 @@ export default function DocumentsPage() {
                       </Button>
                       <Button
                         onClick={() => handleShare(previewModal.document)}
-                        className="flex-1 bg-gray-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors flex items-center justify-center space-x-2"
+                        className="flex-1 bg-gray-600 dark:bg-slate-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700 dark:hover:bg-slate-700 transition-colors flex items-center justify-center space-x-2"
                       >
                         <Share2 className="h-4 w-4" />
                         <span>Share</span>

--- a/src/app/(dashboard)/messaging/page.tsx
+++ b/src/app/(dashboard)/messaging/page.tsx
@@ -117,17 +117,17 @@ export default function SecureMessagingPage() {
   );
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] overflow-hidden">
-      <aside className="w-80 border-r border-slate-200 flex flex-col">
-        <div className="p-4 border-b border-slate-200">
+    <div className="flex h-[calc(100vh-4rem)] overflow-hidden bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100">
+      <aside className="w-80 border-r border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex flex-col">
+        <div className="p-4 border-b border-slate-200 dark:border-slate-700">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-5 w-5" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-5 w-5" />
             <Input
               type="text"
               placeholder="Search conversations..."
               value={searchTerm}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-              className="pl-10 pr-4 py-2 w-full"
+              className="pl-10 pr-4 py-2 w-full dark:bg-slate-900 dark:text-slate-100"
             />
           </div>
         </div>
@@ -135,32 +135,32 @@ export default function SecureMessagingPage() {
           {filteredConversations.map(conv => (
             <div
               key={conv.id}
-              className={`p-4 border-b border-slate-200 cursor-pointer hover:bg-slate-50 ${
-                selectedConversation?.id === conv.id ? 'bg-slate-50' : ''
+              className={`p-4 border-b border-slate-200 dark:border-slate-700 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700 ${
+                selectedConversation?.id === conv.id ? 'bg-slate-50 dark:bg-slate-700' : ''
               }`}
               onClick={() => setSelectedConversation(conv)}
             >
               <div className="flex justify-between items-center mb-1">
-                <h3 className="font-medium text-slate-900">{conv.name}</h3>
-                <span className="text-xs text-slate-500">
+                <h3 className="font-medium text-slate-900 dark:text-slate-100">{conv.name}</h3>
+                <span className="text-xs text-slate-500 dark:text-slate-400">
                   {new Date(conv.timestamp).toLocaleDateString()}
                 </span>
               </div>
-              <p className="text-sm text-slate-600 truncate">{conv.lastMessage}</p>
+              <p className="text-sm text-slate-600 dark:text-slate-400 truncate">{conv.lastMessage}</p>
             </div>
           ))}
         </div>
       </aside>
-      <section className="flex-1 flex flex-col">
-        <div className="flex items-center justify-between p-4 border-b border-slate-200">
+      <section className="flex-1 flex flex-col bg-white dark:bg-slate-900">
+        <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
           <div>
-            <h2 className="font-semibold text-slate-900">{selectedConversation?.name}</h2>
-            <p className="text-sm text-slate-500">{selectedConversation?.role}</p>
+            <h2 className="font-semibold text-slate-900 dark:text-slate-100">{selectedConversation?.name}</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">{selectedConversation?.role}</p>
           </div>
           <div className="flex items-center space-x-2">
-            <Phone className="h-5 w-5 text-slate-500" />
-            <Video className="h-5 w-5 text-slate-500" />
-            <MoreVertical className="h-5 w-5 text-slate-500" />
+            <Phone className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+            <Video className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+            <MoreVertical className="h-5 w-5 text-slate-500 dark:text-slate-400" />
           </div>
         </div>
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
@@ -173,7 +173,7 @@ export default function SecureMessagingPage() {
                 className={`max-w-lg p-3 rounded-lg ${
                   message.type === 'sent'
                     ? 'bg-blue-600 text-white'
-                    : 'bg-slate-100 text-slate-900'
+                    : 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100'
                 }`}
               >
                 <p className="text-sm mb-1">{message.content}</p>
@@ -185,13 +185,13 @@ export default function SecureMessagingPage() {
           ))}
           <div ref={messagesEndRef} />
         </div>
-        <div className="p-4 border-t border-slate-200">
+        <div className="p-4 border-t border-slate-200 dark:border-slate-700">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
             <div className="flex items-center space-x-2">
               <Input
                 type="text"
                 placeholder="Type a message..."
-                className="flex-1"
+                className="flex-1 dark:bg-slate-900 dark:text-slate-100"
                 {...register('message')}
               />
               <Button type="submit" className="px-4">

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -127,7 +127,7 @@ export default function ReportsAnalyticsPage() {
     const headers = Object.keys(currentData[0]);
 
     const rows = currentData.map(row =>
-      headers.map(h => String((row as Record<string, unknown>)[h] ?? '')).join(',')
+      headers.map(h => String((row as unknown as Record<string, unknown>)[h] ?? '')).join(',')
 
     );
     const csv = [headers.join(','), ...rows].join('\n');
@@ -144,13 +144,13 @@ export default function ReportsAnalyticsPage() {
   const currentData = performanceData[selectedPeriod];
 
   return (
-    <div ref={reportRef} className="p-4 sm:p-6 lg:p-8">
+    <div ref={reportRef} className="min-h-screen p-4 sm:p-6 lg:p-8 text-slate-900 dark:text-slate-100">
       {/* Header */}
       <div className="mb-8">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-slate-900 mb-2">Reports & Analytics</h1>
-            <p className="text-slate-600">Comprehensive portfolio analysis and performance insights</p>
+            <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-2">Reports & Analytics</h1>
+            <p className="text-slate-600 dark:text-slate-400">Comprehensive portfolio analysis and performance insights</p>
           </div>
           
           {/* Export Actions */}
@@ -165,12 +165,12 @@ export default function ReportsAnalyticsPage() {
             </Button>
             
             {showExportMenu && (
-              <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-slate-200 z-10">
+              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 z-10">
                 <div className="py-1">
                   <Button
                     onClick={handleExportPDF}
                     variant="ghost"
-                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
+                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700"
                   >
                     <FileText className="h-4 w-4 text-red-500" />
                     <span>Export as PDF</span>
@@ -178,7 +178,7 @@ export default function ReportsAnalyticsPage() {
                   <Button
                     onClick={handleExportImage}
                     variant="ghost"
-                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
+                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700"
                   >
                     <ImageIcon className="h-4 w-4 text-green-500" />
                     <span>Export as Image</span>
@@ -186,7 +186,7 @@ export default function ReportsAnalyticsPage() {
                   <Button
                     onClick={handleExportData}
                     variant="ghost"
-                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50"
+                    className="flex items-center space-x-2 w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700"
                   >
                     <Grid3X3 className="h-4 w-4 text-blue-500" />
                     <span>Export Data (CSV)</span>
@@ -199,15 +199,15 @@ export default function ReportsAnalyticsPage() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-8">
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 mb-8">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
           {/* Time Period Filter */}
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
-              <Calendar className="h-5 w-5 text-slate-500" />
-              <span className="font-medium text-slate-700">Time Period:</span>
+              <Calendar className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+              <span className="font-medium text-slate-700 dark:text-slate-300">Time Period:</span>
             </div>
-            <div className="flex space-x-1 bg-slate-100 rounded-lg p-1">
+            <div className="flex space-x-1 bg-slate-100 dark:bg-slate-700 rounded-lg p-1">
               {['1M', '3M', '1Y'].map((period) => (
                 <Button
                   key={period}
@@ -215,8 +215,8 @@ export default function ReportsAnalyticsPage() {
                   variant="ghost"
                   className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
                     selectedPeriod === period
-                      ? 'bg-white text-slate-900 shadow-sm'
-                      : 'text-slate-600 hover:text-slate-900'
+                      ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 shadow-sm'
+                      : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
                   }`}
                 >
                   {period}
@@ -228,13 +228,13 @@ export default function ReportsAnalyticsPage() {
           {/* Portfolio Filter */}
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
-              <Filter className="h-5 w-5 text-slate-500" />
-              <span className="font-medium text-slate-700">Portfolio:</span>
+              <Filter className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+              <span className="font-medium text-slate-700 dark:text-slate-300">Portfolio:</span>
             </div>
             <Select
               value={selectedPortfolio}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSelectedPortfolio(e.target.value)}
-              className="px-3 py-2"
+              className="px-3 py-2 dark:bg-slate-900 dark:text-slate-100"
             >
               <option value="all">All Portfolios</option>
               <option value="growth">Growth Portfolio</option>
@@ -245,13 +245,13 @@ export default function ReportsAnalyticsPage() {
 
           {/* Chart Type Selector */}
           <div className="flex items-center space-x-2">
-            <span className="font-medium text-slate-700">View:</span>
-            <div className="flex space-x-1 bg-slate-100 rounded-lg p-1">
+            <span className="font-medium text-slate-700 dark:text-slate-300">View:</span>
+            <div className="flex space-x-1 bg-slate-100 dark:bg-slate-700 rounded-lg p-1">
               <Button
                 onClick={() => setChartType('line')}
                 variant="ghost"
                 className={`p-2 rounded-md transition-colors ${
-                  chartType === 'line' ? 'bg-white shadow-sm' : 'hover:bg-slate-200'
+                  chartType === 'line' ? 'bg-white dark:bg-slate-800 shadow-sm' : 'hover:bg-slate-200 dark:hover:bg-slate-600'
                 }`}
                 title="Line Chart"
               >
@@ -261,7 +261,7 @@ export default function ReportsAnalyticsPage() {
                 onClick={() => setChartType('area')}
                 variant="ghost"
                 className={`p-2 rounded-md transition-colors ${
-                  chartType === 'area' ? 'bg-white shadow-sm' : 'hover:bg-slate-200'
+                  chartType === 'area' ? 'bg-white dark:bg-slate-800 shadow-sm' : 'hover:bg-slate-200 dark:hover:bg-slate-600'
                 }`}
                 title="Area Chart"
               >
@@ -273,17 +273,17 @@ export default function ReportsAnalyticsPage() {
       </div>
 
       {/* Portfolio Performance Chart */}
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-8">
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 mb-8">
         <div className="flex items-center justify-between mb-6">
-          <h3 className="text-lg font-semibold text-slate-900">Portfolio Performance vs Benchmark</h3>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Portfolio Performance vs Benchmark</h3>
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-              <span className="text-sm text-slate-600">Portfolio</span>
+              <span className="text-sm text-slate-600 dark:text-slate-400">Portfolio</span>
             </div>
             <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-slate-400 rounded-full"></div>
-              <span className="text-sm text-slate-600">Benchmark</span>
+              <span className="text-sm text-slate-600 dark:text-slate-400">Benchmark</span>
             </div>
           </div>
         </div>
@@ -294,8 +294,8 @@ export default function ReportsAnalyticsPage() {
               <LineChart data={currentData}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
                 <XAxis dataKey="period" stroke="#64748b" fontSize={12} />
-                <YAxis 
-                  stroke="#64748b" 
+                <YAxis
+                  stroke="#64748b"
                   fontSize={12}
                   tickFormatter={(value) => `$${(value / 1000000).toFixed(1)}M`}
                 />
@@ -368,8 +368,8 @@ export default function ReportsAnalyticsPage() {
       {/* Asset Allocation & Sector Analysis */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
         {/* Asset Allocation */}
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold text-slate-900 mb-6">Asset Allocation</h3>
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-6">Asset Allocation</h3>
           <div className="h-64 mb-4">
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
@@ -403,15 +403,15 @@ export default function ReportsAnalyticsPage() {
             {assetAllocationData.map((item, index) => (
               <div key={index} className="flex items-center justify-between py-1">
                 <div className="flex items-center space-x-2">
-                  <div 
+                  <div
                     className="w-3 h-3 rounded-full"
                     style={{ backgroundColor: item.color }}
                   ></div>
-                  <span className="text-sm text-slate-700">{item.name}</span>
+                  <span className="text-sm text-slate-700 dark:text-slate-300">{item.name}</span>
                 </div>
                 <div className="text-right">
-                  <span className="text-sm font-medium text-slate-900">{item.value}%</span>
-                  <div className="text-xs text-slate-500">{formatCurrency(item.amount)}</div>
+                  <span className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.value}%</span>
+                  <div className="text-xs text-slate-500 dark:text-slate-400">{formatCurrency(item.amount)}</div>
                 </div>
               </div>
             ))}
@@ -419,17 +419,17 @@ export default function ReportsAnalyticsPage() {
         </div>
 
         {/* Sector Performance */}
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold text-slate-900 mb-6">Sector Performance</h3>
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-6">Sector Performance</h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={sectorData} layout="horizontal">
                 <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
                 <XAxis type="number" stroke="#64748b" fontSize={11} />
-                <YAxis 
-                  type="category" 
-                  dataKey="sector" 
-                  stroke="#64748b" 
+                <YAxis
+                  type="category"
+                  dataKey="sector"
+                  stroke="#64748b"
                   fontSize={11}
                   width={80}
                 />
@@ -438,7 +438,7 @@ export default function ReportsAnalyticsPage() {
                       name === 'allocation' ? `${value}%` : `${formatPercent(value)}`,
                       name === 'allocation' ? 'Allocation' : 'Performance'
                     ]}
-                  />
+                />
                 <Bar dataKey="allocation" fill="#0ea5e9" />
                 <Bar dataKey="performance" fill="#14b8a6" />
               </BarChart>
@@ -450,8 +450,8 @@ export default function ReportsAnalyticsPage() {
       {/* Income Analysis & Risk Metrics */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
         {/* Income Analysis */}
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold text-slate-900 mb-6">Income Analysis</h3>
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-6">Income Analysis</h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={incomeData}>
@@ -471,35 +471,35 @@ export default function ReportsAnalyticsPage() {
         </div>
 
         {/* Risk Metrics Table */}
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold text-slate-900 mb-6">Risk Metrics</h3>
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-6">Risk Metrics</h3>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b border-slate-200">
-                  <th className="text-left py-3 px-2 font-medium text-slate-700">Metric</th>
-                  <th className="text-right py-3 px-2 font-medium text-slate-700">Portfolio</th>
-                  <th className="text-right py-3 px-2 font-medium text-slate-700">Benchmark</th>
-                  <th className="text-right py-3 px-2 font-medium text-slate-700">Target</th>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  <th className="text-left py-3 px-2 font-medium text-slate-700 dark:text-slate-300">Metric</th>
+                  <th className="text-right py-3 px-2 font-medium text-slate-700 dark:text-slate-300">Portfolio</th>
+                  <th className="text-right py-3 px-2 font-medium text-slate-700 dark:text-slate-300">Benchmark</th>
+                  <th className="text-right py-3 px-2 font-medium text-slate-700 dark:text-slate-300">Target</th>
                 </tr>
               </thead>
               <tbody>
                 {riskMetricsData.map((metric, index) => (
-                  <tr key={index} className="border-b border-slate-100">
-                    <td className="py-3 px-2 text-slate-900">{metric.metric}</td>
-                    <td className="py-3 px-2 text-right font-medium text-slate-900">
-                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown' 
-                        ? `${metric.portfolio}%` 
+                  <tr key={index} className="border-b border-slate-100 dark:border-slate-700">
+                    <td className="py-3 px-2 text-slate-900 dark:text-slate-100">{metric.metric}</td>
+                    <td className="py-3 px-2 text-right font-medium text-slate-900 dark:text-slate-100">
+                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown'
+                        ? `${metric.portfolio}%`
                         : metric.portfolio}
                     </td>
-                    <td className="py-3 px-2 text-right text-slate-600">
-                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown' 
-                        ? `${metric.benchmark}%` 
+                    <td className="py-3 px-2 text-right text-slate-600 dark:text-slate-400">
+                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown'
+                        ? `${metric.benchmark}%`
                         : metric.benchmark}
                     </td>
-                    <td className="py-3 px-2 text-right text-slate-500">
-                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown' 
-                        ? `${metric.target}%` 
+                    <td className="py-3 px-2 text-right text-slate-500 dark:text-slate-400">
+                      {metric.metric.includes('%') || metric.metric === 'Max Drawdown'
+                        ? `${metric.target}%`
                         : metric.target}
                     </td>
                   </tr>
@@ -511,12 +511,12 @@ export default function ReportsAnalyticsPage() {
       </div>
 
       {/* Performance Summary */}
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-        <h3 className="text-lg font-semibold text-slate-900 mb-6">Performance Summary</h3>
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-6">Performance Summary</h3>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           <div className="text-center">
             <div className="text-2xl font-bold text-green-600 mb-1">+12.4%</div>
-            <div className="text-sm text-slate-600">YTD Return</div>
+            <div className="text-sm text-slate-600 dark:text-slate-400">YTD Return</div>
           </div>
           <div className="text-center">
             <div className="text-2xl font-bold text-blue-600 mb-1">+18.7%</div>

--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -174,27 +174,27 @@ export default function TasksNotificationsPage() {
   };
 
   return (
-    <div className="p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen p-4 sm:p-6 lg:p-8 text-slate-900 dark:text-slate-100">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-slate-900 mb-2">Tasks & Notifications</h1>
-        <p className="text-slate-600">Manage your pending tasks and stay updated with important notifications</p>
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-2">Tasks & Notifications</h1>
+        <p className="text-slate-600 dark:text-slate-400">Manage your pending tasks and stay updated with important notifications</p>
       </div>
 
       {/* Notification Banner */}
       {showNotificationBanner && unreadCount > 0 && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6 flex items-center justify-between">
+        <div className="bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded-lg p-4 mb-6 flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <Bell className="h-5 w-5 text-blue-600" />
             <div>
-              <p className="font-medium text-blue-900">You have {unreadCount} unread notifications</p>
-              <p className="text-sm text-blue-700">Stay updated with your latest account activities</p>
+              <p className="font-medium text-blue-900 dark:text-blue-100">You have {unreadCount} unread notifications</p>
+              <p className="text-sm text-blue-700 dark:text-blue-300">Stay updated with your latest account activities</p>
             </div>
           </div>
           <Button
             onClick={() => setShowNotificationBanner(false)}
             variant="ghost"
-            className="text-blue-500 hover:text-blue-700"
+            className="text-blue-500 dark:text-blue-300 hover:text-blue-700 dark:hover:text-blue-100"
           >
             <X className="h-5 w-5" />
           </Button>
@@ -202,14 +202,14 @@ export default function TasksNotificationsPage() {
       )}
 
       {/* Tabs */}
-      <div className="flex space-x-1 bg-slate-100 rounded-lg p-1 mb-6 w-fit">
+      <div className="flex space-x-1 bg-slate-100 dark:bg-slate-700 rounded-lg p-1 mb-6 w-fit">
         <Button
           onClick={() => setActiveTab('tasks')}
           variant="ghost"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors relative ${
             activeTab === 'tasks'
-              ? 'bg-white text-slate-900 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900'
+              ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 shadow-sm'
+              : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
           }`}
         >
           Tasks
@@ -224,8 +224,8 @@ export default function TasksNotificationsPage() {
           variant="ghost"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors relative ${
             activeTab === 'notifications'
-              ? 'bg-white text-slate-900 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900'
+              ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 shadow-sm'
+              : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
           }`}
         >
           Notifications
@@ -242,28 +242,28 @@ export default function TasksNotificationsPage() {
         <div>
           {/* Task Stats */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-            <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-slate-600">Pending Tasks</p>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">Pending Tasks</p>
                   <p className="text-2xl font-bold text-orange-600">{taskCounts.pending}</p>
                 </div>
                 <Clock className="h-8 w-8 text-orange-600" />
               </div>
             </div>
-            <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-slate-600">In Progress</p>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">In Progress</p>
                   <p className="text-2xl font-bold text-blue-600">{taskCounts['in-progress']}</p>
                 </div>
                 <AlertCircle className="h-8 w-8 text-blue-600" />
               </div>
             </div>
-            <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-slate-600">Completed</p>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">Completed</p>
                   <p className="text-2xl font-bold text-green-600">{taskCounts.completed}</p>
                 </div>
                 <CheckCircle className="h-8 w-8 text-green-600" />
@@ -272,15 +272,15 @@ export default function TasksNotificationsPage() {
           </div>
 
           {/* Task Filters */}
-          <div className="bg-white rounded-lg border border-slate-200 p-4 mb-6">
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 mb-6">
             <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
               {/* Search */}
               <div className="relative flex-1 max-w-md">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-4 w-4" />
                 <Input
                   type="text"
                   placeholder="Search tasks..."
-                  className="w-full pl-10 pr-4 py-2 text-sm"
+                  className="w-full pl-10 pr-4 py-2 text-sm dark:bg-slate-900 dark:text-slate-100"
                   {...register('search')}
                 />
                 {errors.search && (
@@ -291,7 +291,7 @@ export default function TasksNotificationsPage() {
               {/* Filters */}
               <div className="flex items-center space-x-4">
                 <div className="flex flex-col">
-                  <Select className="px-3 py-2 text-sm" {...register('status')}>
+                  <Select className="px-3 py-2 text-sm dark:bg-slate-900 dark:text-slate-100" {...register('status')}>
                     <option value="all">All Status</option>
                     <option value="pending">Pending</option>
                     <option value="in-progress">In Progress</option>
@@ -303,7 +303,7 @@ export default function TasksNotificationsPage() {
                 </div>
 
                 <div className="flex flex-col">
-                  <Select className="px-3 py-2 text-sm" {...register('priority')}>
+                  <Select className="px-3 py-2 text-sm dark:bg-slate-900 dark:text-slate-100" {...register('priority')}>
                     <option value="all">All Priority</option>
                     <option value="high">High</option>
                     <option value="medium">Medium</option>
@@ -325,16 +325,16 @@ export default function TasksNotificationsPage() {
               const priorityInfo = priorityConfig[task.priority as keyof typeof priorityConfig];
 
               return (
-                <div key={task.id} className="bg-white rounded-lg border border-slate-200 p-6 hover:shadow-md transition-shadow">
+                <div key={task.id} className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 hover:shadow-md transition-shadow">
                   <div className="flex items-start justify-between">
                     <div className="flex items-start space-x-4 flex-1">
-                      <div className="bg-slate-100 p-3 rounded-lg">
-                        <Icon className="h-6 w-6 text-slate-600" />
+                      <div className="bg-slate-100 dark:bg-slate-700 p-3 rounded-lg">
+                        <Icon className="h-6 w-6 text-slate-600 dark:text-slate-300" />
                       </div>
-                      
+
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center space-x-3 mb-2">
-                          <h3 className="font-semibold text-slate-900">{task.title}</h3>
+                          <h3 className="font-semibold text-slate-900 dark:text-slate-100">{task.title}</h3>
                           <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusInfo.bg} ${statusInfo.color}`}>
                             {statusInfo.label}
                           </span>
@@ -342,10 +342,10 @@ export default function TasksNotificationsPage() {
                             {priorityInfo.label} Priority
                           </span>
                         </div>
-                        
-                        <p className="text-slate-600 mb-3">{task.description}</p>
-                        
-                        <div className="flex items-center justify-between text-sm text-slate-500">
+
+                        <p className="text-slate-600 dark:text-slate-400 mb-3">{task.description}</p>
+
+                        <div className="flex items-center justify-between text-sm text-slate-500 dark:text-slate-400">
                           <div className="flex items-center space-x-4">
                             <span>Due: {formatDate(task.dueDate)}</span>
                             <span>Created: {formatDate(task.createdAt)}</span>
@@ -358,7 +358,7 @@ export default function TasksNotificationsPage() {
                       {task.status === 'pending' && (
                         <Button
                           onClick={() => handleTaskStatusUpdate(task.id, 'in-progress')}
-                          className="px-3 py-1 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors text-sm"
+                          className="px-3 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-100 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors text-sm"
                         >
                           Start
                         </Button>
@@ -366,7 +366,7 @@ export default function TasksNotificationsPage() {
                       {task.status === 'in-progress' && (
                         <Button
                           onClick={() => handleTaskStatusUpdate(task.id, 'completed')}
-                          className="px-3 py-1 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors text-sm"
+                          className="px-3 py-1 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 rounded-lg hover:bg-green-200 dark:hover:bg-green-800 transition-colors text-sm"
                         >
                           Complete
                         </Button>
@@ -377,7 +377,7 @@ export default function TasksNotificationsPage() {
                           <span className="text-sm font-medium">Done</span>
                         </div>
                       )}
-                      <Button variant="ghost" className="p-2 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+                      <Button variant="ghost" className="p-2 text-slate-400 dark:text-slate-300 hover:text-slate-600 dark:hover:text-slate-100 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700">
                         <MoreVertical className="h-4 w-4" />
                       </Button>
                     </div>
@@ -390,8 +390,8 @@ export default function TasksNotificationsPage() {
           {filteredTasks.length === 0 && (
             <div className="text-center py-12">
               <CheckCircle className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-              <h3 className="text-lg font-semibold text-slate-900 mb-2">No tasks found</h3>
-              <p className="text-slate-600">Try adjusting your search or filter criteria.</p>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">No tasks found</h3>
+              <p className="text-slate-600 dark:text-slate-400">Try adjusting your search or filter criteria.</p>
             </div>
           )}
         </div>
@@ -403,9 +403,9 @@ export default function TasksNotificationsPage() {
           {/* Notification Actions */}
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center space-x-4">
-              <h2 className="text-lg font-semibold text-slate-900">Recent Notifications</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Recent Notifications</h2>
               {unreadCount > 0 && (
-                <span className="px-2 py-1 bg-red-100 text-red-700 rounded-full text-sm font-medium">
+                <span className="px-2 py-1 bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-100 rounded-full text-sm font-medium">
                   {unreadCount} unread
                 </span>
               )}
@@ -414,7 +414,7 @@ export default function TasksNotificationsPage() {
               <Button
                 onClick={handleMarkAllAsRead}
                 variant="ghost"
-                className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                className="text-blue-600 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-100 text-sm font-medium"
               >
                 Mark all as read
               </Button>
@@ -430,29 +430,29 @@ export default function TasksNotificationsPage() {
               return (
                 <div
                   key={notification.id}
-                  className={`bg-white border border-slate-200 rounded-lg p-4 hover:shadow-sm transition-shadow cursor-pointer ${
+                  className={`bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-sm transition-shadow cursor-pointer ${
                     !notification.read ? 'border-l-4 border-l-blue-500' : ''
                   }`}
                   onClick={() => handleMarkAsRead(notification.id)}
                 >
                   <div className="flex items-start space-x-4">
-                    <div className={`p-2 rounded-lg ${typeInfo.bg}`}>
+                    <div className={`p-2 rounded-lg ${typeInfo.bg}`}> 
                       <Icon className={`h-5 w-5 ${typeInfo.color}`} />
                     </div>
-                    
+
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between mb-1">
-                        <h4 className={`font-medium ${!notification.read ? 'text-slate-900' : 'text-slate-700'}`}>
+                        <h4 className={`font-medium ${!notification.read ? 'text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}>
                           {notification.title}
                         </h4>
                         <div className="flex items-center space-x-2">
-                          <span className="text-xs text-slate-500">{formatTimestamp(notification.timestamp)}</span>
+                          <span className="text-xs text-slate-500 dark:text-slate-400">{formatTimestamp(notification.timestamp)}</span>
                           {!notification.read && (
                             <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
                           )}
                         </div>
                       </div>
-                      <p className={`text-sm ${!notification.read ? 'text-slate-600' : 'text-slate-500'}`}>
+                      <p className={`text-sm ${!notification.read ? 'text-slate-600 dark:text-slate-400' : 'text-slate-500 dark:text-slate-400'}`}>
                         {notification.message}
                       </p>
                     </div>
@@ -465,8 +465,8 @@ export default function TasksNotificationsPage() {
           {notifications.length === 0 && (
             <div className="text-center py-12">
               <Bell className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-              <h3 className="text-lg font-semibold text-slate-900 mb-2">No notifications</h3>
-              <p className="text-slate-600">You&apos;re all caught up! New notifications will appear here.</p>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">No notifications</h3>
+              <p className="text-slate-600 dark:text-slate-400">You&apos;re all caught up! New notifications will appear here.</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add dark theme styling to dashboard documents, accounts, messaging, tasks, and reports pages
- ensure nested cards, tables, and modals respond to theme toggles

## Testing
- `npm test`
- `npm run build` (fails: Module '"next-themes"' has no exported member 'ThemeProvider')

------
https://chatgpt.com/codex/tasks/task_e_68940ccbcf4883329a3aac5a9b9c948e